### PR TITLE
fix: degrade mockito as test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.9.5</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Mockito was bundled as transitive dependency in 0.1.0. oops