### PR TITLE
! add exception handling for BufferExhaustedExceptions 

### DIFF
--- a/src/main/java/com/github/danielwegener/logback/kafka/delivery/AsynchronousDeliveryStrategy.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/delivery/AsynchronousDeliveryStrategy.java
@@ -1,5 +1,6 @@
 package com.github.danielwegener.logback.kafka.delivery;
 
+import org.apache.kafka.clients.producer.BufferExhaustedException;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -9,16 +10,21 @@ public class AsynchronousDeliveryStrategy implements DeliveryStrategy {
 
     @Override
     public <K, V, E> boolean send(Producer<K, V> producer, ProducerRecord<K, V> record, final E event,
-                               final FailedDeliveryCallback<E> failedDeliveryCallback) {
-        producer.send(record, new Callback() {
-            @Override
-            public void onCompletion(RecordMetadata metadata, Exception exception) {
-                if (exception != null) {
-                    failedDeliveryCallback.onFailedDelivery(event, exception);
+                                  final FailedDeliveryCallback<E> failedDeliveryCallback) {
+        try {
+            producer.send(record, new Callback() {
+                @Override
+                public void onCompletion(RecordMetadata metadata, Exception exception) {
+                    if (exception != null) {
+                        failedDeliveryCallback.onFailedDelivery(event, exception);
+                    }
                 }
-            }
-        });
-        return true;
+            });
+            return true;
+        } catch (BufferExhaustedException e) {
+            failedDeliveryCallback.onFailedDelivery(event, e);
+            return false;
+        }
     }
 
 }

--- a/src/main/java/com/github/danielwegener/logback/kafka/delivery/BlockingDeliveryStrategy.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/delivery/BlockingDeliveryStrategy.java
@@ -1,6 +1,7 @@
 package com.github.danielwegener.logback.kafka.delivery;
 
 import ch.qos.logback.core.spi.ContextAwareBase;
+import org.apache.kafka.clients.producer.BufferExhaustedException;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -19,6 +20,7 @@ public class BlockingDeliveryStrategy extends ContextAwareBase implements Delive
             return true;
         }
         catch (InterruptedException e) { return false; }
+        catch (BufferExhaustedException e) { failureCallback.onFailedDelivery(event, e); }
         catch (ExecutionException e)  { failureCallback.onFailedDelivery(event, e); }
         catch (TimeoutException e) { failureCallback.onFailedDelivery(event, e); }
         return false;


### PR DESCRIPTION
for cases where producerConfig block.on.buffer.full=false the DeliveryStrategies should use the fallback callback.