### PR TITLE
Lazy initialize producer and defer Kafka log events: #1

### DIFF
--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppender.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppender.java
@@ -7,12 +7,4 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
  */
 public class KafkaAppender extends KafkaAppenderBase<ILoggingEvent> {
 
-    private static final String KAFKA_LOGGER_PREFIX = "org.apache.kafka";
-
-    @Override
-    public void doAppend(ILoggingEvent eventObject) {
-        if (eventObject.getLoggerName().startsWith(KAFKA_LOGGER_PREFIX)) return;
-        super.doAppend(eventObject);
-    }
-
 }

--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderBase.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderBase.java
@@ -2,61 +2,30 @@ package com.github.danielwegener.logback.kafka;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
-import ch.qos.logback.core.spi.FilterReply;
 import com.github.danielwegener.logback.kafka.delivery.FailedDeliveryCallback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.slf4j.Logger;
-import org.slf4j.helpers.SubstituteLogger;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class KafkaAppenderBase<E extends ILoggingEvent> extends KafkaAppenderConfig<E> {
 
-    protected Producer<byte[], byte[]> createProducer() {
-        final ByteArraySerializer serializer = new ByteArraySerializer();
-        return new KafkaProducer<byte[], byte[]>(new HashMap<String, Object>(producerConfig), serializer, serializer);
-    }
-
-    public KafkaAppenderBase() {
-        addFilter(new Filter<E>() {
-            @Override
-            public FilterReply decide(E event) {
-                if (event.getLoggerName().startsWith(KAFKA_LOGGER_PREFIX)) {
-                    return FilterReply.DENY;
-                }
-                return FilterReply.NEUTRAL;
-            }
-        });
-    }
-
     /**
      * Kafka clients uses this prefix for its slf4j logging.
-     * This appender should never ever log any of its logs since it could cause harmful infinite recursion/self feeding effects.
+     * This appender defers appends of any Kafka logs since it could cause harmful infinite recursion/self feeding effects.
      */
     private static final String KAFKA_LOGGER_PREFIX = "org.apache.kafka.clients";
 
-
+    private LazyProducer lazyProducer = null;
     private final AppenderAttachableImpl<E> aai = new AppenderAttachableImpl<E>();
-    private Producer<byte[], byte[]> producer = null;
-
-
-    @Override
-    protected void append(E e) {
-        final byte[] payload = encoder.doEncode(e);
-        final byte[] key = keyingStrategy.createKey(e);
-        final ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[],byte[]>(topic, key, payload);
-        deliveryStrategy.send(producer,record, e, failedDeliveryCallback);
-    }
-
+    private final ConcurrentLinkedQueue<E> queue = new ConcurrentLinkedQueue<E>();
     private final FailedDeliveryCallback<E> failedDeliveryCallback = new FailedDeliveryCallback<E>() {
         @Override
         public void onFailedDelivery(E evt, Throwable throwable) {
@@ -64,34 +33,43 @@ public class KafkaAppenderBase<E extends ILoggingEvent> extends KafkaAppenderCon
         }
     };
 
+    public KafkaAppenderBase() {
+        // setting these as config values sidesteps an unnecessary warning (minor bug in KafkaProducer)
+        addProducerConfigValue(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        addProducerConfigValue(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+    }
+
+    @Override
+    public void doAppend(E e) {
+        ensureDeferredAppends();
+        if (e.getLoggerName().startsWith(KAFKA_LOGGER_PREFIX)) {
+            deferAppend(e);
+        } else {
+            super.doAppend(e);
+        }
+    }
 
     @Override
     public void start() {
         // only error free appenders should be activated
         if (!checkPrerequisites()) return;
 
-
-        producer = createProducer();
+        lazyProducer = new LazyProducer();
 
         super.start();
     }
 
     @Override
     public void stop() {
-        if (producer != null) {
+        super.stop();
+        if (lazyProducer != null && lazyProducer.isInitialized()) {
             try {
-                producer.close();
+                lazyProducer.get().close();
             } catch (KafkaException e) {
                 this.addWarn("Failed to shut down kafka producer: " + e.getMessage(), e);
             }
-            producer = null;
+            lazyProducer = null;
         }
-        super.stop();
-    }
-
-    @Override
-    public boolean isStarted() {
-        return super.isStarted();
     }
 
     @Override
@@ -128,4 +106,66 @@ public class KafkaAppenderBase<E extends ILoggingEvent> extends KafkaAppenderCon
     public boolean detachAppender(String name) {
         return aai.detachAppender(name);
     }
+
+    @Override
+    protected void append(E e) {
+        final byte[] payload = encoder.doEncode(e);
+        final byte[] key = keyingStrategy.createKey(e);
+        final ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[],byte[]>(topic, key, payload);
+        deliveryStrategy.send(lazyProducer.get(), record, e, failedDeliveryCallback);
+    }
+
+    protected Producer<byte[], byte[]> createProducer() {
+        return new KafkaProducer<byte[], byte[]>(new HashMap<String, Object>(producerConfig));
+    }
+
+    private void deferAppend(E event) {
+        queue.add(event);
+    }
+
+    // drains queue events to super
+    private void ensureDeferredAppends() {
+        E event;
+
+        while ((event = queue.poll()) != null) {
+            super.doAppend(event);
+        }
+    }
+
+    /**
+     * Lazy initializer for producer, patterned after commons-lang.
+     *
+     * @see <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-3.4/org/apache/commons/lang3/concurrent/LazyInitializer.html">LazyInitializer</a>
+     */
+    private class LazyProducer {
+
+        private volatile Producer<byte[], byte[]> producer;
+
+        public Producer<byte[], byte[]> get() {
+            Producer<byte[], byte[]> result = this.producer;
+            if (result == null) {
+                synchronized(this) {
+                    result = this.producer;
+                    if(result == null) {
+                        this.producer = result = this.initialize();
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        protected Producer<byte[], byte[]> initialize() {
+            Producer<byte[], byte[]> producer = null;
+            try {
+                producer = createProducer();
+            } catch (Exception e) {
+                addError("error creating producer", e);
+            }
+            return producer;
+        }
+
+        public boolean isInitialized() { return producer != null; }
+    }
+
 }


### PR DESCRIPTION
Addresses #1.

Also addresses throwing away all Kafka log messages.

Also addresses the undesirable situation in which an appender is configured but not referenced in the logback config -- it will still start a KafkaProducer.

The cost of polling the ConcurrentLinkedQueue used to defer internal Kafka events is about 60 nanos on my machine, which should be acceptable in all cases.