### PR TITLE
Missing config keys having a default value are reporting an info status

### DIFF
--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
@@ -66,17 +66,17 @@ public abstract class KafkaAppenderConfig<E> extends UnsynchronizedAppenderBase<
         }
 
         if (topic == null) {
-            addStatus(new ErrorStatus("No topic set for the appender named [\"" + name + "\"].", this));
+            addError("No topic set for the appender named [\"" + name + "\"].");
             errorFree = false;
         }
 
         if (encoder == null) {
-            addStatus(new ErrorStatus("No encoder set for the appender named [\"" + name + "\"].", this));
+            addError("No encoder set for the appender named [\"" + name + "\"].");
             errorFree = false;
         }
 
         if (keyingStrategy == null) {
-            addError("No partitionStrategy set for the appender named [\"" + name + "\"]. Using default RoundRobin strategy.");
+            addInfo("No partitionStrategy set for the appender named [\"" + name + "\"]. Using default RoundRobin strategy.");
             keyingStrategy = new RoundRobinKeyingStrategy();
         }
 


### PR DESCRIPTION
- Missing config keys having a default value are reporting an info status
- Missing config keys without value are reporting an error status.

This fixes #17 