### PR TITLE
Switching default delivery strategy to asynchronous instead of blocking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ###Changed
 - Fixed typos in logback warning messages emitted by `com.github.danielwegener.logback.kafka.KafkaAppenderConfig` (#28)
+- Switched default delivery strategy to `com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy` as it is the [more sensible default](https://github.com/danielwegener/logback-kafka-appender/pull/32). 
 
 ## [0.1.0] - 2016-02-07
 ###Changed

--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
@@ -2,6 +2,7 @@ package com.github.danielwegener.logback.kafka;
 
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.spi.AppenderAttachable;
+import com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy;
 import com.github.danielwegener.logback.kafka.delivery.BlockingDeliveryStrategy;
 import com.github.danielwegener.logback.kafka.delivery.DeliveryStrategy;
 import com.github.danielwegener.logback.kafka.encoding.KafkaMessageEncoder;
@@ -91,8 +92,8 @@ public abstract class KafkaAppenderConfig<E> extends UnsynchronizedAppenderBase<
         }
 
         if (deliveryStrategy == null) {
-            addInfo("No sendStrategy set for the appender named [\""+name+"\"]. Using default Blocking strategy.");
-            deliveryStrategy = new BlockingDeliveryStrategy();
+            addInfo("No sendStrategy set for the appender named [\""+name+"\"]. Using default asynchronous strategy.");
+            deliveryStrategy = new AsynchronousDeliveryStrategy();
         }
 
         return errorFree;

--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
@@ -3,7 +3,6 @@ package com.github.danielwegener.logback.kafka;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.spi.AppenderAttachable;
 import com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy;
-import com.github.danielwegener.logback.kafka.delivery.BlockingDeliveryStrategy;
 import com.github.danielwegener.logback.kafka.delivery.DeliveryStrategy;
 import com.github.danielwegener.logback.kafka.encoding.KafkaMessageEncoder;
 import com.github.danielwegener.logback.kafka.keying.KeyingStrategy;


### PR DESCRIPTION
The blocking strategy can be a problem in production environments so asynchronous delivery would be a  kinder default for people who do not read documentation. Like me. ;)