### PR TITLE
Modify the kafka initialized blocking problem

### DIFF
--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppender.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppender.java
@@ -24,7 +24,7 @@ public class KafkaAppender<E> extends KafkaAppenderConfig<E> {
      * Kafka clients uses this prefix for its slf4j logging.
      * This appender defers appends of any Kafka logs since it could cause harmful infinite recursion/self feeding effects.
      */
-    private static final String KAFKA_LOGGER_PREFIX = "org.apache.kafka.clients";
+    private static final String KAFKA_LOGGER_PREFIX = "org.apache.kafka";
 
     private LazyProducer lazyProducer = null;
     private final AppenderAttachableImpl<E> aai = new AppenderAttachableImpl<E>();
@@ -44,10 +44,10 @@ public class KafkaAppender<E> extends KafkaAppenderConfig<E> {
 
     @Override
     public void doAppend(E e) {
-        ensureDeferredAppends();
         if (e instanceof ILoggingEvent && ((ILoggingEvent)e).getLoggerName().startsWith(KAFKA_LOGGER_PREFIX)) {
             deferAppend(e);
         } else {
+            ensureDeferredAppends();
             super.doAppend(e);
         }
     }


### PR DESCRIPTION
Modify the kafka initialized blocking problem.

logback config:

deliveryStrategy：BlockingDeliveryStrategy

<root level="debug">
    <appender-ref ref="KafkaAppender" />
</root>

Kafka produces a log of packages that have：
org.apache.kafka.clients
org.apache.kafka.common

