### PR TITLE
Osgi compatibility

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+Export-Package: com.github.danielwegener.logback.kafka.*

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <developerConnection>scm:git:git@github.com:danielwegener/logback-kafka-appender.git</developerConnection>
         <url>git@github.com:danielwegener/logback-kafka-appender.git</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <developers>
         <developer>
@@ -102,7 +102,6 @@
             <version>1.7.10</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.carrotsearch</groupId>
             <artifactId>junit-benchmarks</artifactId>
@@ -163,11 +162,25 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>default-bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.0.2</version>
                 <configuration>
                     <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>


### PR DESCRIPTION
Fixes danielwegener/logback-kafka-appender#2

All packages are exported

The new bnd-maven-plugin is the prefered way to generate OSGi-metadata from Maven.
The bnd.bnd file is used to control the output (similar to a POM), but the plugin already manages most of the information provided by maven.