### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-###Changed
+### Changed
 - Fixed typos in logback warning messages emitted by `com.github.danielwegener.logback.kafka.KafkaAppenderConfig` (#28)
 - Switched default delivery strategy to `com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy` as it is the [more sensible default](https://github.com/danielwegener/logback-kafka-appender/pull/32). 
 
 ## [0.1.0] - 2016-02-07
-###Changed
+### Changed
 - Class `com.github.danielwegener.logback.kafka.KafkaAppenderBase` has been inlined into the `KafkaAppender`.
 - Class `com.github.danielwegener.logback.kafka.encoding.PatternLayoutKafkaMessageEncoder` has been renamed to `com.github.danielwegener.logback.kafka.encoding.LayoutKafkaMessageEncoder` (#9). To ease the migration, there is still a deprecated class alias `PatternLayoutKafkaMessageEncoder`. You should change your logback.xml to `LayoutKafkaMessageEncoder` as soon as possible!
 - `KafkaAppender`, `KeyingStrategy` and `LayoutKafkaMessageEncoder` are now generic and can now be used with alternative logback implementations like logback-access (#16)!
 
 ## [0.0.5] - 2015-12-23
-###Changed
+### Changed
 - Upgrade to kafka 0.9.0. This includes that __Java 6 is no longer supported__.
 - Using of deprecated kafka configuration is reported as logback warning. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#logback-kafka-appender
+# logback-kafka-appender
 
 [![Join the chat at https://gitter.im/danielwegener/logback-kafka-appender](https://badges.gitter.im/danielwegener/logback-kafka-appender.svg)](https://gitter.im/danielwegener/logback-kafka-appender?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
