### PR TITLE
Add support for kafka client version 0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,26 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>0.9.0.0</version>
+            <artifactId>kafka_2.11</artifactId>
+            <version>0.8.2.2</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jmxtools</artifactId>
+                    <groupId>com.sun.jdmk</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jmxri</artifactId>
+                    <groupId>com.sun.jmx</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jms</artifactId>
+                    <groupId>javax.jms</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -80,22 +98,7 @@
             <version>1.1.2</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
-            <version>0.9.0.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-log4j12</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>log4j</artifactId>
-                    <groupId>log4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>

--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppenderConfig.java
@@ -7,12 +7,13 @@ import com.github.danielwegener.logback.kafka.delivery.DeliveryStrategy;
 import com.github.danielwegener.logback.kafka.encoding.KafkaMessageEncoder;
 import com.github.danielwegener.logback.kafka.keying.KeyingStrategy;
 import com.github.danielwegener.logback.kafka.keying.RoundRobinKeyingStrategy;
-import static org.apache.kafka.clients.producer.ProducerConfig.*;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static org.apache.kafka.clients.producer.ProducerConfig.*;
 
 /**
  * @since 0.0.1
@@ -30,13 +31,13 @@ public abstract class KafkaAppenderConfig<E> extends UnsynchronizedAppenderBase<
     static {
         KNOWN_PRODUCER_CONFIG_KEYS.add(BOOTSTRAP_SERVERS_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(METADATA_FETCH_TIMEOUT_CONFIG);
-        DEPRECATED_PRODUCER_CONFIG_KEYS.put(METADATA_FETCH_TIMEOUT_CONFIG, MAX_BLOCK_MS_CONFIG);
+//        DEPRECATED_PRODUCER_CONFIG_KEYS.put(METADATA_FETCH_TIMEOUT_CONFIG, MAX_BLOCK_MS_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(METADATA_MAX_AGE_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(BATCH_SIZE_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(BUFFER_MEMORY_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(ACKS_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(TIMEOUT_CONFIG);
-        DEPRECATED_PRODUCER_CONFIG_KEYS.put(METADATA_FETCH_TIMEOUT_CONFIG, REQUEST_TIMEOUT_MS_CONFIG);
+//        DEPRECATED_PRODUCER_CONFIG_KEYS.put(METADATA_FETCH_TIMEOUT_CONFIG, REQUEST_TIMEOUT_MS_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(LINGER_MS_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(CLIENT_ID_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(SEND_BUFFER_CONFIG);
@@ -54,10 +55,10 @@ public abstract class KafkaAppenderConfig<E> extends UnsynchronizedAppenderBase<
         KNOWN_PRODUCER_CONFIG_KEYS.add(MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
         KNOWN_PRODUCER_CONFIG_KEYS.add(KEY_SERIALIZER_CLASS_CONFIG);
         KNOWN_PRODUCER_CONFIG_KEYS.add(VALUE_SERIALIZER_CLASS_CONFIG);
-        KNOWN_PRODUCER_CONFIG_KEYS.add(CONNECTIONS_MAX_IDLE_MS_CONFIG);
-        KNOWN_PRODUCER_CONFIG_KEYS.add(PARTITIONER_CLASS_CONFIG);
-        KNOWN_PRODUCER_CONFIG_KEYS.add(MAX_BLOCK_MS_CONFIG);
-        KNOWN_PRODUCER_CONFIG_KEYS.add(REQUEST_TIMEOUT_MS_CONFIG);
+//        KNOWN_PRODUCER_CONFIG_KEYS.add(CONNECTIONS_MAX_IDLE_MS_CONFIG);
+//        KNOWN_PRODUCER_CONFIG_KEYS.add(PARTITIONER_CLASS_CONFIG);
+//        KNOWN_PRODUCER_CONFIG_KEYS.add(MAX_BLOCK_MS_CONFIG);
+//        KNOWN_PRODUCER_CONFIG_KEYS.add(REQUEST_TIMEOUT_MS_CONFIG);
     }
 
     protected Map<String,Object> producerConfig = new HashMap<String, Object>();

--- a/src/test/java/com/github/danielwegener/logback/kafka/util/EmbeddedKafkaCluster.java
+++ b/src/test/java/com/github/danielwegener/logback/kafka/util/EmbeddedKafkaCluster.java
@@ -2,7 +2,6 @@ package com.github.danielwegener.logback.kafka.util;
 
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
-import scala.Some;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -89,7 +88,7 @@ public class EmbeddedKafkaCluster {
 
 
     private KafkaServer startBroker(Properties props) {
-        KafkaServer server = new KafkaServer(new KafkaConfig(props), new SystemTime(), Some.apply("embedded-kafka-cluster"));
+        KafkaServer server = new KafkaServer(new KafkaConfig(props), new SystemTime());
         server.startup();
         return server;
     }


### PR DESCRIPTION
Since we kafka-0.8 series is still widely used, and i think we need to support it.I just remove some config key defined in KafkaAppenderConfig.java which could not be found in kafka-client-0.8.2.2.jar