### PR TITLE
Adjust the KafkaAppender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 target
 .idea
 *.iml
+.settings/org.eclipse.m2e.core.prefs
+.settings/org.eclipse.jdt.apt.core.prefs
+.classpath
+.project
+.settings/org.eclipse.core.resources.prefs
+.settings/org.eclipse.jdt.core.prefs

--- a/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppender.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/KafkaAppender.java
@@ -24,7 +24,7 @@ public class KafkaAppender<E> extends KafkaAppenderConfig<E> {
      * Kafka clients uses this prefix for its slf4j logging.
      * This appender defers appends of any Kafka logs since it could cause harmful infinite recursion/self feeding effects.
      */
-    private static final String KAFKA_LOGGER_PREFIX = KafkaProducer.class.getPackage().getName().replaceFirst("\\.producer$", "");
+    private static final String KAFKA_LOGGER_PREFIX = KafkaProducer.class.getPackage().getName().replaceFirst("\\.clients\\.producer$", "");
 
     private LazyProducer lazyProducer = null;
     private final AppenderAttachableImpl<E> aai = new AppenderAttachableImpl<E>();
@@ -46,7 +46,10 @@ public class KafkaAppender<E> extends KafkaAppenderConfig<E> {
     public void doAppend(E e) {
         ensureDeferredAppends();
         if (e instanceof ILoggingEvent && ((ILoggingEvent)e).getLoggerName().startsWith(KAFKA_LOGGER_PREFIX)) {
-            deferAppend(e);
+            //only in case the producer is initialized we are able to send messages.
+            if ( (lazyProducer != null ) && lazyProducer.isInitialized() ) {
+                deferAppend(e);
+            }
         } else {
             super.doAppend(e);
         }

--- a/src/test/java/com/github/danielwegener/logback/kafka/KafkaAppenderTest.java
+++ b/src/test/java/com/github/danielwegener/logback/kafka/KafkaAppenderTest.java
@@ -136,7 +136,6 @@ public class KafkaAppenderTest {
 
         final LoggingEvent evt = new LoggingEvent("fqcn",ctx.getLogger("logger"), Level.ALL, "message", null, new Object[0]);
         unit.doAppend(evt);
-        verify(deliveryStrategy).send(any(KafkaProducer.class), any(ProducerRecord.class), eq(deferredEvent), any(FailedDeliveryCallback.class));
         verify(deliveryStrategy).send(any(KafkaProducer.class), any(ProducerRecord.class), eq(evt), any(FailedDeliveryCallback.class));
     }
 
@@ -147,7 +146,7 @@ public class KafkaAppenderTest {
             constField.setAccessible(true);
         }
         String constValue = (String) constField.get(null);
-        assertThat(constValue, equalTo("org.apache.kafka.clients"));
+        assertThat(constValue, equalTo("org.apache.kafka"));
     }
 
 


### PR DESCRIPTION
The appender is not starting when the org.kafka is set to DEBUG. It results that the solutions can't start kafka. By checking if the procedure is activated the message can be appended. In other cases the messages are dropped.