### PR TITLE
don't crash the app on nonfatal failure

### DIFF
--- a/src/main/java/com/github/danielwegener/logback/kafka/delivery/AsynchronousDeliveryStrategy.java
+++ b/src/main/java/com/github/danielwegener/logback/kafka/delivery/AsynchronousDeliveryStrategy.java
@@ -16,16 +16,13 @@ public class AsynchronousDeliveryStrategy implements DeliveryStrategy {
     public <K, V, E> boolean send(Producer<K, V> producer, ProducerRecord<K, V> record, final E event,
                                   final FailedDeliveryCallback<E> failedDeliveryCallback) {
         try {
-            producer.send(record, new Callback() {
-                @Override
-                public void onCompletion(RecordMetadata metadata, Exception exception) {
-                    if (exception != null) {
-                        failedDeliveryCallback.onFailedDelivery(event, exception);
-                    }
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    failedDeliveryCallback.onFailedDelivery(event, exception);
                 }
             });
             return true;
-        } catch (BufferExhaustedException | TimeoutException e) {
+        } catch (Exception e) {
             failedDeliveryCallback.onFailedDelivery(event, e);
             return false;
         }


### PR DESCRIPTION
This change is to avoid propagating Kafka error to the application rather always use the fallback on any Kafka failure. There's no point in having a fallback if the main appender kills the application on failure.